### PR TITLE
feat: create user procurement history api

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { ProcurementModule } from './procurement/procurement.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    ProcurementModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/procurement/dto/create-procurement.dto.ts
+++ b/backend/src/procurement/dto/create-procurement.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsNumber, IsPositive } from 'class-validator';
+
+export class CreateProcurementDto {
+  @IsString()
+  @IsNotEmpty()
+  readonly itemName: string;
+
+  @IsNumber()
+  @IsPositive()
+  readonly quantity: number;
+
+  @IsNumber()
+  @IsPositive()
+  readonly cost: number;
+}

--- a/backend/src/procurement/dto/update-procurement.dto.ts
+++ b/backend/src/procurement/dto/update-procurement.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProcurementDto } from './create-procurement.dto';
+
+export class UpdateProcurementDto extends PartialType(CreateProcurementDto) {}

--- a/backend/src/procurement/entities/procurement.entity.ts
+++ b/backend/src/procurement/entities/procurement.entity.ts
@@ -1,0 +1,29 @@
+import { User } from 'src/users/user.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+} from 'typeorm';
+
+@Entity()
+export class Procurement {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  itemName: string;
+
+  @Column('int')
+  quantity: number;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  cost: number;
+
+  @CreateDateColumn()
+  procurementDate: Date;
+
+  @ManyToOne(() => User, (user) => user.procurements, { eager: false })
+  owner: User;
+}

--- a/backend/src/procurement/procurement.controller.spec.ts
+++ b/backend/src/procurement/procurement.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcurementController } from './procurement.controller';
+import { ProcurementService } from './procurement.service';
+
+describe('ProcurementController', () => {
+  let controller: ProcurementController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProcurementController],
+      providers: [ProcurementService],
+    }).compile();
+
+    controller = module.get<ProcurementController>(ProcurementController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/procurement/procurement.controller.spec.ts
+++ b/backend/src/procurement/procurement.controller.spec.ts
@@ -1,20 +1,78 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProcurementController } from './procurement.controller';
 import { ProcurementService } from './procurement.service';
+import { CreateProcurementDto } from './dto/create-procurement.dto';
+import { JwtAuthGuard } from 'src/auth/jwt.guard';
 
 describe('ProcurementController', () => {
   let controller: ProcurementController;
+  let service: ProcurementService;
+
+  const mockProcurementService = {
+    create: jest.fn(),
+    findAllForUser: jest.fn(),
+  };
+
+  const mockRequest = {
+    user: {
+      userId: 'user-uuid-123',
+    },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProcurementController],
-      providers: [ProcurementService],
-    }).compile();
+      providers: [
+        {
+          provide: ProcurementService,
+          useValue: mockProcurementService,
+        },
+      ],
+    })
+      // Mock the guard to bypass actual authentication
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     controller = module.get<ProcurementController>(ProcurementController);
+    service = module.get<ProcurementService>(ProcurementService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should call the service to create a procurement record', async () => {
+      const createDto: CreateProcurementDto = {
+        itemName: 'New Laptop',
+        quantity: 1,
+        cost: 1500,
+      };
+      const expectedResult = { id: 'proc-uuid-456', ...createDto };
+      mockProcurementService.create.mockResolvedValue(expectedResult);
+
+      const result = await controller.create(createDto, mockRequest);
+
+      expect(service.create).toHaveBeenCalledWith(
+        createDto,
+        mockRequest.user.userId,
+      );
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should call the service to get all records for the user', async () => {
+      const expectedResult = [{ itemName: 'Old Records' }];
+      mockProcurementService.findAllForUser.mockResolvedValue(expectedResult);
+
+      const result = await controller.findAll(mockRequest);
+
+      expect(service.findAllForUser).toHaveBeenCalledWith(
+        mockRequest.user.userId,
+      );
+      expect(result).toEqual(expectedResult);
+    });
   });
 });

--- a/backend/src/procurement/procurement.controller.ts
+++ b/backend/src/procurement/procurement.controller.ts
@@ -1,0 +1,29 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ProcurementService } from './procurement.service';
+import { CreateProcurementDto } from './dto/create-procurement.dto';
+import { JwtAuthGuard } from 'src/auth/jwt.guard';
+
+@UseGuards(JwtAuthGuard)
+@Controller('procurement')
+export class ProcurementController {
+  constructor(private readonly procurementService: ProcurementService) {}
+
+  @Post()
+  create(@Body() createProcurementDto: CreateProcurementDto, @Request() req) {
+    const userId = req.user.userId;
+    return this.procurementService.create(createProcurementDto, userId);
+  }
+
+  @Get()
+  findAll(@Request() req) {
+    const userId = req.user.userId;
+    return this.procurementService.findAllForUser(userId);
+  }
+}

--- a/backend/src/procurement/procurement.module.ts
+++ b/backend/src/procurement/procurement.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProcurementService } from './procurement.service';
+import { ProcurementController } from './procurement.controller';
+import { Procurement } from './entities/procurement.entity';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Procurement]), AuthModule],
+  controllers: [ProcurementController],
+  providers: [ProcurementService],
+})
+export class ProcurementModule {}

--- a/backend/src/procurement/procurement.service.spec.ts
+++ b/backend/src/procurement/procurement.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcurementService } from './procurement.service';
+
+describe('ProcurementService', () => {
+  let service: ProcurementService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProcurementService],
+    }).compile();
+
+    service = module.get<ProcurementService>(ProcurementService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/procurement/procurement.service.spec.ts
+++ b/backend/src/procurement/procurement.service.spec.ts
@@ -1,18 +1,81 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { ProcurementService } from './procurement.service';
+import { Procurement } from './entities/procurement.entity';
+import { CreateProcurementDto } from './dto/create-procurement.dto';
 
 describe('ProcurementService', () => {
   let service: ProcurementService;
+  let repository: Repository<Procurement>;
+
+  const mockProcurementRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const userId = 'user-uuid-123';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ProcurementService],
+      providers: [
+        ProcurementService,
+        {
+          provide: getRepositoryToken(Procurement),
+          useValue: mockProcurementRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<ProcurementService>(ProcurementService);
+    repository = module.get<Repository<Procurement>>(
+      getRepositoryToken(Procurement),
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create and save a new procurement record for a user', async () => {
+      const createDto: CreateProcurementDto = {
+        itemName: 'Test Item',
+        quantity: 10,
+        cost: 99.99,
+      };
+      const expectedRecord = { ...createDto, owner: { id: userId } };
+
+      // Mock the repository methods
+      mockProcurementRepository.create.mockReturnValue(expectedRecord);
+      mockProcurementRepository.save.mockResolvedValue(expectedRecord);
+
+      const result = await service.create(createDto, userId);
+
+      expect(mockProcurementRepository.create).toHaveBeenCalledWith({
+        ...createDto,
+        owner: { id: userId },
+      });
+      expect(mockProcurementRepository.save).toHaveBeenCalledWith(
+        expectedRecord,
+      );
+      expect(result).toEqual(expectedRecord);
+    });
+  });
+
+  describe('findAllForUser', () => {
+    it('should find and return all procurement records for a specific user', async () => {
+      const mockRecords = [{ itemName: 'Item 1' }, { itemName: 'Item 2' }];
+      mockProcurementRepository.find.mockResolvedValue(mockRecords);
+
+      const result = await service.findAllForUser(userId);
+
+      expect(mockProcurementRepository.find).toHaveBeenCalledWith({
+        where: { owner: { id: userId } },
+        order: { procurementDate: 'DESC' },
+      });
+      expect(result).toEqual(mockRecords);
+    });
   });
 });

--- a/backend/src/procurement/procurement.service.ts
+++ b/backend/src/procurement/procurement.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateProcurementDto } from './dto/create-procurement.dto';
+import { Procurement } from './entities/procurement.entity';
+
+@Injectable()
+export class ProcurementService {
+  constructor(
+    @InjectRepository(Procurement)
+    private readonly procurementRepository: Repository<Procurement>,
+  ) {}
+
+  async create(
+    createProcurementDto: CreateProcurementDto,
+    userId: string,
+  ): Promise<Procurement> {
+    const newProcurement = this.procurementRepository.create({
+      ...createProcurementDto,
+      owner: { id: userId },
+    });
+
+    return this.procurementRepository.save(newProcurement);
+  }
+
+  async findAllForUser(userId: string): Promise<Procurement[]> {
+    return this.procurementRepository.find({
+      where: {
+        owner: { id: userId },
+      },
+      order: {
+        procurementDate: 'DESC',
+      },
+    });
+  }
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Procurement } from 'src/procurement/entities/procurement.entity';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 
 @Entity()
 export class User {
@@ -13,4 +14,7 @@ export class User {
 
   @Column({ default: 'farmer' })
   role: string;
+
+  @OneToMany(() => Procurement, (procurement) => procurement.owner)
+  procurements: Procurement[];
 }


### PR DESCRIPTION
This PR adds the functionality for users to track their procurement history.

**Key Changes:**

- Creates a new procurement module, including the entity, service, and controller.
- Implements `POST` `/procurement` for an authenticated user to save a new record.
- Implements `GET` `/procurement` for an authenticated user to retrieve their entire history.
- Secures both endpoints with `JwtAuthGuard` to ensure users can only access their own data.
- Add tests

Closes #6 