### PR TITLE
feat: create service for mock weather data

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { WeatherModule } from './weather/weather.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    WeatherModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/weather/dto/create-weather.dto.ts
+++ b/backend/src/weather/dto/create-weather.dto.ts
@@ -1,0 +1,1 @@
+export class CreateWeatherDto {}

--- a/backend/src/weather/dto/update-weather.dto.ts
+++ b/backend/src/weather/dto/update-weather.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateWeatherDto } from './create-weather.dto';
+
+export class UpdateWeatherDto extends PartialType(CreateWeatherDto) {}

--- a/backend/src/weather/entities/weather.entity.ts
+++ b/backend/src/weather/entities/weather.entity.ts
@@ -1,0 +1,1 @@
+export class Weather {}

--- a/backend/src/weather/weather.controller.spec.ts
+++ b/backend/src/weather/weather.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WeatherController } from './weather.controller';
+import { WeatherService } from './weather.service';
+
+describe('WeatherController', () => {
+  let controller: WeatherController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WeatherController],
+      providers: [WeatherService],
+    }).compile();
+
+    controller = module.get<WeatherController>(WeatherController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/weather/weather.controller.ts
+++ b/backend/src/weather/weather.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { WeatherService } from './weather.service';
+import { CreateWeatherDto } from './dto/create-weather.dto';
+import { UpdateWeatherDto } from './dto/update-weather.dto';
+
+@Controller('weather')
+export class WeatherController {
+  constructor(private readonly weatherService: WeatherService) {}
+
+  @Post()
+  create(@Body() createWeatherDto: CreateWeatherDto) {
+    return this.weatherService.create(createWeatherDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.weatherService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.weatherService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateWeatherDto: UpdateWeatherDto) {
+    return this.weatherService.update(+id, updateWeatherDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.weatherService.remove(+id);
+  }
+}

--- a/backend/src/weather/weather.module.ts
+++ b/backend/src/weather/weather.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { WeatherService } from './weather.service';
+
+@Module({
+  providers: [WeatherService],
+  exports: [WeatherService],
+})
+export class WeatherModule {}

--- a/backend/src/weather/weather.service.spec.ts
+++ b/backend/src/weather/weather.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WeatherService, WeatherData } from './weather.service';
+
+describe('WeatherService', () => {
+  let service: WeatherService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WeatherService],
+    }).compile();
+
+    service = module.get<WeatherService>(WeatherService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getWeatherByLocation', () => {
+    it('should return mock weather data for a given location', async () => {
+      const location = 'Abuja';
+      const weatherData: WeatherData =
+        await service.getWeatherByLocation(location);
+
+      expect(weatherData).toBeDefined();
+
+      expect(weatherData.location).toEqual(location);
+
+      expect(weatherData).toHaveProperty('temperature');
+      expect(typeof weatherData.temperature).toBe('number');
+
+      expect(weatherData).toHaveProperty('humidity');
+      expect(typeof weatherData.humidity).toBe('number');
+
+      expect(weatherData).toHaveProperty('rainfallPrediction');
+      expect(typeof weatherData.rainfallPrediction).toBe('string');
+    });
+  });
+});

--- a/backend/src/weather/weather.service.ts
+++ b/backend/src/weather/weather.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface WeatherData {
+  location: string;
+  temperature: number;
+  humidity: number;
+  windSpeed: number;
+  rainfallPrediction: 'High' | 'Medium' | 'Low' | 'None';
+}
+
+@Injectable()
+export class WeatherService {
+  private readonly logger = new Logger(WeatherService.name);
+
+  async getWeatherByLocation(location: string): Promise<WeatherData> {
+    this.logger.log(`Fetching mock weather for location: ${location}`);
+
+    const mockWeatherData: WeatherData = {
+      location: location,
+      temperature: 28.5,
+      humidity: 82,
+      windSpeed: 15,
+      rainfallPrediction: 'Medium',
+    };
+
+    return Promise.resolve(mockWeatherData);
+  }
+}


### PR DESCRIPTION
This PR introduces a `WeatherService` to provide simulated weather data for different locations. This service acts as a placeholder for a real weather API and will be used by the upcoming farm recommendations logic.

**Key Changes:**

- Created `WeatherService` with a `getWeatherByLocation` method that returns a hardcoded JSON response.
- Added unit tests to verify the service returns data in the expected format.
- Exported the service from WeatherModule for future use across the application. 

Closes #7 