### PR TITLE
feat(auth): implement role-based access control

### DIFF
--- a/backend/src/auth/guards/roles.guard.spec.ts
+++ b/backend/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,56 @@
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../roles/role.enum';
+import { ExecutionContext } from '@nestjs/common';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  // Helper to create a mock ExecutionContext
+  const createMockExecutionContext = (user: any): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+      getHandler: () => {},
+      getClass: () => {},
+    }) as any;
+
+  it('should allow access if no roles are required', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    const mockContext = createMockExecutionContext({ roles: [Role.User] });
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+
+  it('should deny access if user has no roles', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [] });
+    expect(guard.canActivate(mockContext)).toBe(false);
+  });
+
+  it('should deny access if user does not have the required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [Role.User] });
+    expect(guard.canActivate(mockContext)).toBe(false);
+  });
+
+  it('should allow access if user has the required role', () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+    const mockContext = createMockExecutionContext({ roles: [Role.Admin] });
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+
+  it('should allow access if user has one of the multiple required roles', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.Admin, Role.User]);
+    const mockContext = createMockExecutionContext({ roles: [Role.User] });
+    expect(guard.canActivate(mockContext)).toBe(true);
+  });
+});

--- a/backend/src/auth/guards/roles.guard.ts
+++ b/backend/src/auth/guards/roles.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../roles/role.enum';
+import { ROLES_KEY } from '../roles/role.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+
+    return requiredRoles.some((role) => user.roles?.includes(role));
+  }
+}

--- a/backend/src/auth/roles/role.decorator.ts
+++ b/backend/src/auth/roles/role.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from './role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/auth/roles/role.enum.ts
+++ b/backend/src/auth/roles/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  User = 'user',
+  Admin = 'admin',
+}


### PR DESCRIPTION
This PR introduces a flexible system for role-based access control. It allows developers to restrict access to specific endpoints based on `user` roles.

**Key Changes:**
- RolesGuard: A new guard that checks if a user has the required role(s) to access an endpoint.
- @Roles() Decorator: A custom decorator to specify which roles are permitted (e.g., `@Roles(Role.Admin)`).
- Role Enum: A centralized enum for defining user roles (User, Admin).

Closes #8 