### PR TITLE
PR: feat(vendors): Implement Vendor Management CRUD API

### DIFF
--- a/backend/src/recommendations/recommendations.controller.spec.ts
+++ b/backend/src/recommendations/recommendations.controller.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RecommendationsController } from './recommendations.controller';
+import { RecommendationsService } from './recommendations.service';
+import { NotFoundException } from '@nestjs/common';
+
+// Create a mock service to isolate the controller tests
+const mockRecommendationsService = {
+  getRecommendationsForFarm: jest.fn(),
+};
+
+describe('RecommendationsController', () => {
+  let controller: RecommendationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RecommendationsController],
+      providers: [
+        {
+          provide: RecommendationsService,
+          useValue: mockRecommendationsService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<RecommendationsController>(RecommendationsController);
+  });
+
+  afterEach(() => {
+    // Clear mock history after each test
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getRecommendations', () => {
+    it('should call the service with the correct farmId and return its result', () => {
+      const farmId = 'farm-101';
+      const mockResponse = {
+        farmDetails: { farmId: 'farm-101', cropType: 'Maize', sizeInAcres: 5 },
+        recommendedInputs: [{ input: 'NPK', quantity: '15 bags' }],
+      };
+
+      // Setup the mock to return a specific value when called
+      mockRecommendationsService.getRecommendationsForFarm.mockReturnValue(
+        mockResponse,
+      );
+
+      const result = controller.getRecommendations(farmId);
+
+      // Check that the service was called with the correct parameter
+      expect(
+        mockRecommendationsService.getRecommendationsForFarm,
+      ).toHaveBeenCalledWith(farmId);
+
+      // Check that the controller returns the value from the service
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should propagate exceptions from the service', () => {
+      const invalidFarmId = 'farm-999';
+
+      // Setup the mock to throw an error when called
+      mockRecommendationsService.getRecommendationsForFarm.mockImplementation(
+        () => {
+          throw new NotFoundException(
+            `Farm with ID "${invalidFarmId}" not found.`,
+          );
+        },
+      );
+
+      // Verify that the controller throws the same exception
+      expect(() => controller.getRecommendations(invalidFarmId)).toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/backend/src/recommendations/recommendations.controller.ts
+++ b/backend/src/recommendations/recommendations.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { RecommendationsService } from './recommendations.service';
+
+@Controller('recommendations')
+export class RecommendationsController {
+  constructor(private readonly recommendationsService: RecommendationsService) {}
+
+  /**
+   * Defines the GET /recommendations/:farmId endpoint.
+   * @param farmId The farm ID from the URL parameter.
+   * @returns The result from the RecommendationsService.
+   */
+  @Get(':farmId')
+  getRecommendations(@Param('farmId') farmId: string) {
+    return this.recommendationsService.getRecommendationsForFarm(farmId);
+  }
+}

--- a/backend/src/recommendations/recommendations.module.ts
+++ b/backend/src/recommendations/recommendations.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RecommendationsController } from './recommendations.controller';
+import { RecommendationsService } from './recommendations.service';
+
+@Module({
+  controllers: [RecommendationsController],
+  providers: [RecommendationsService],
+})
+export class RecommendationsModule {}

--- a/backend/src/recommendations/recommendations.service.spec.ts
+++ b/backend/src/recommendations/recommendations.service.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RecommendationsService } from './recommendations.service';
+import { NotFoundException } from '@nestjs/common';
+
+describe('RecommendationsService', () => {
+  let service: RecommendationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RecommendationsService],
+    }).compile();
+
+    service = module.get<RecommendationsService>(RecommendationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getRecommendationsForFarm', () => {
+    it('should return recommendations for a valid Maize farm', () => {
+      const farmId = 'farm-101'; // A 5-acre Maize farm
+      const result = service.getRecommendationsForFarm(farmId);
+
+      expect(result).toBeDefined();
+      expect(result.farmDetails.farmId).toEqual(farmId);
+      expect(result.farmDetails.cropType).toEqual('Maize');
+      expect(result.recommendedInputs.length).toBeGreaterThan(0);
+      // Check if calculations are correct based on size
+      expect(result.recommendedInputs[0].quantity).toContain('15 bags'); // 5 acres * 3 bags
+      expect(result.recommendedInputs[1].quantity).toContain('20 kg'); // 5 acres * 4 kg
+    });
+
+    it('should return recommendations for a valid Rice farm', () => {
+      const farmId = 'farm-102'; // A 10-acre Rice farm
+      const result = service.getRecommendationsForFarm(farmId);
+
+      expect(result).toBeDefined();
+      expect(result.farmDetails.cropType).toEqual('Rice');
+      expect(result.recommendedInputs.length).toBeGreaterThan(0);
+      expect(result.recommendedInputs[0].quantity).toContain('40 bags'); // 10 acres * 4 bags
+    });
+
+    it('should throw NotFoundException for an invalid farmId', () => {
+      const invalidFarmId = 'farm-999';
+      // We wrap the function call in a lambda to test if it throws an error
+      expect(() => service.getRecommendationsForFarm(invalidFarmId)).toThrow(
+        NotFoundException,
+      );
+      expect(() => service.getRecommendationsForFarm(invalidFarmId)).toThrow(
+        `Farm with ID "${invalidFarmId}" not found.`,
+      );
+    });
+  });
+});

--- a/backend/src/recommendations/recommendations.service.ts
+++ b/backend/src/recommendations/recommendations.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+// --- Mock Data ---
+// In a real application, you would fetch this from a database.
+const mockFarms = [
+  { farmId: 'farm-101', cropType: 'Maize', sizeInAcres: 5 },
+  { farmId: 'farm-102', cropType: 'Rice', sizeInAcres: 10 },
+  { farmId: 'farm-103', cropType: 'Cassava', sizeInAcres: 2 },
+  { farmId: 'farm-104', cropType: 'Maize', sizeInAcres: 15 },
+];
+
+@Injectable()
+export class RecommendationsService {
+  /**
+   * Generates mock input recommendations for a given farm ID.
+   * @param farmId The ID of the farm to get recommendations for.
+   * @returns An object containing the farm details and recommended inputs.
+   */
+  getRecommendationsForFarm(farmId: string) {
+    // 1. Find the farm in our mock database.
+    const farm = mockFarms.find((f) => f.farmId === farmId);
+
+    if (!farm) {
+      throw new NotFoundException(`Farm with ID "${farmId}" not found.`);
+    }
+
+    // 2. Generate recommendations based on the farm's crop type and size.
+    let suggestions = [];
+    const { cropType, sizeInAcres } = farm;
+
+    switch (cropType) {
+      case 'Maize':
+        suggestions = [
+          {
+            input: 'NPK 15-15-15 Fertilizer',
+            quantity: `${sizeInAcres * 3} bags`,
+            reason: 'Essential for early-stage maize growth.',
+          },
+          {
+            input: 'Maize Seeds (Hybrid Variety)',
+            quantity: `${sizeInAcres * 4} kg`,
+            reason: 'High-yield variety suitable for this farm size.',
+          },
+          {
+            input: 'Herbicide (Pre-emergence)',
+            quantity: `${sizeInAcres * 1} liters`,
+            reason: 'Controls weeds before they can compete with the crop.',
+          },
+        ];
+        break;
+
+      case 'Rice':
+        suggestions = [
+          {
+            input: 'Urea Fertilizer',
+            quantity: `${sizeInAcres * 4} bags`,
+            reason: 'High nitrogen content boosts leaf growth for paddy rice.',
+          },
+          {
+            input: 'Rice Seedlings (FARO 44)',
+            quantity: `${sizeInAcres * 25} kg`,
+            reason: 'A popular and resilient long-grain variety.',
+          },
+        ];
+        break;
+
+      case 'Cassava':
+        suggestions = [
+          {
+            input: 'Muriate of Potash (MOP)',
+            quantity: `${sizeInAcres * 2} bags`,
+            reason: 'Potassium is crucial for tuber development in cassava.',
+          },
+          {
+            input: 'Cassava Stems (TME 419)',
+            quantity: `${sizeInAcres * 60} bundles`,
+            reason: 'A disease-resistant and high-yield variety.',
+          },
+        ];
+        break;
+
+      default:
+        suggestions = [
+          {
+            input: 'No recommendations available',
+            quantity: 'N/A',
+            reason: `Recommendations for crop type "${cropType}" are not yet implemented.`,
+          },
+        ];
+        break;
+    }
+
+    return {
+      farmDetails: farm,
+      recommendedInputs: suggestions,
+    };
+  }
+}

--- a/backend/src/vendors/controller.spec.ts
+++ b/backend/src/vendors/controller.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VendorsController } from './vendors.controller';
+import { VendorsService } from './vendors.service';
+import { RolesGuard } from '../auth/roles.guard';
+import { CanActivate } from '@nestjs/common';
+
+// Mock the service so we can test the controller in isolation
+const mockVendorsService = {
+  create: jest.fn((dto) => ({ id: 'new-id', ...dto })),
+  findAll: jest.fn(() => [{ id: 'vendor-1', name: 'Test Vendor' }]),
+  findOne: jest.fn((id) => ({ id, name: 'Test Vendor' })),
+  update: jest.fn((id, dto) => ({ id, ...dto })),
+  remove: jest.fn((id) => ({
+    message: `Vendor with ID "${id}" successfully deleted.`,
+  })),
+};
+
+// Mock the guard to always allow access for these tests
+const mockRolesGuard: CanActivate = { canActivate: jest.fn(() => true) };
+
+describe('VendorsController', () => {
+  let controller: VendorsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VendorsController],
+      providers: [
+        {
+          provide: VendorsService,
+          useValue: mockVendorsService,
+        },
+      ],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
+      .compile();
+
+    controller = module.get<VendorsController>(VendorsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should create a vendor', () => {
+    const dto = {
+      name: 'New Vendor',
+      location: 'Test Location',
+      inputsSold: [],
+    };
+    controller.create(dto);
+    expect(mockVendorsService.create).toHaveBeenCalledWith(dto);
+  });
+
+  it('should get all vendors', () => {
+    controller.findAll();
+    expect(mockVendorsService.findAll).toHaveBeenCalled();
+  });
+
+  it('should get a single vendor by id', () => {
+    const id = 'vendor-1';
+    controller.findOne(id);
+    expect(mockVendorsService.findOne).toHaveBeenCalledWith(id);
+  });
+
+  it('should update a vendor', () => {
+    const id = 'vendor-1';
+    const dto = { name: 'Updated Name' };
+    controller.update(id, dto);
+    expect(mockVendorsService.update).toHaveBeenCalledWith(id, dto);
+  });
+
+  it('should delete a vendor', () => {
+    const id = 'vendor-1';
+    controller.remove(id);
+    expect(mockVendorsService.remove).toHaveBeenCalledWith(id);
+  });
+});

--- a/backend/src/vendors/dto/create-vendor.dto.ts
+++ b/backend/src/vendors/dto/create-vendor.dto.ts
@@ -1,0 +1,39 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsArray,
+  ValidateNested,
+  IsDefined,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { Input } from '../entities/vendor.entity';
+
+export class CreateVendorDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  location: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => InputDto) // Important for nested validation
+  @IsDefined()
+  inputsSold: Input[];
+}
+
+// A simple DTO for the nested Input object
+class InputDto implements Input {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  type: 'Fertilizer' | 'Seed' | 'Equipment';
+
+  @IsNotEmpty()
+  price: number;
+}

--- a/backend/src/vendors/dto/update-vendor.dto.ts
+++ b/backend/src/vendors/dto/update-vendor.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateVendorDto } from './create-vendor.dto';
+
+export class UpdateVendorDto extends PartialType(CreateVendorDto) {}

--- a/backend/src/vendors/entities/vendor.entity.ts
+++ b/backend/src/vendors/entities/vendor.entity.ts
@@ -1,0 +1,13 @@
+// An "Input" can be a type or interface defining what vendors sell
+export interface Input {
+  name: string;
+  type: 'Fertilizer' | 'Seed' | 'Equipment';
+  price: number;
+}
+
+export class Vendor {
+  id: string;
+  name: string;
+  location: string;
+  inputsSold: Input[];
+}

--- a/backend/src/vendors/service.spec.ts
+++ b/backend/src/vendors/service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { VendorsService } from './vendors.service';
+import { NotFoundException } from '@nestjs/common';
+import { CreateVendorDto } from './dto/create-vendor.dto';
+
+describe('VendorsService', () => {
+  let service: VendorsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VendorsService],
+    }).compile();
+
+    service = module.get<VendorsService>(VendorsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create and return a new vendor', () => {
+      const createDto: CreateVendorDto = {
+        name: 'Farm Fresh Co.',
+        location: 'California',
+        inputsSold: [{ name: 'Organic Seeds', type: 'Seed', price: 25 }],
+      };
+      const newVendor = service.create(createDto);
+      expect(newVendor).toBeDefined();
+      expect(newVendor.name).toEqual(createDto.name);
+      expect(newVendor.id).toBeDefined();
+      // Check if it was added to the list
+      expect(service.findAll()).toHaveLength(2);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of vendors', () => {
+      const vendors = service.findAll();
+      expect(Array.isArray(vendors)).toBe(true);
+      expect(vendors.length).toBe(1); // The initial mock vendor
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single vendor by id', () => {
+      const vendorId = 'vendor-1';
+      const vendor = service.findOne(vendorId);
+      expect(vendor).toBeDefined();
+      expect(vendor.id).toEqual(vendorId);
+    });
+
+    it('should throw NotFoundException if vendor is not found', () => {
+      expect(() => service.findOne('invalid-id')).toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update and return the vendor', () => {
+      const vendorId = 'vendor-1';
+      const updateDto = { name: 'Updated Agro Supplies' };
+      const updatedVendor = service.update(vendorId, updateDto);
+      expect(updatedVendor.name).toEqual(updateDto.name);
+    });
+
+    it('should throw NotFoundException when trying to update a non-existent vendor', () => {
+      expect(() => service.update('invalid-id', { name: 'test' })).toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a vendor and return a success message', () => {
+      const vendorId = 'vendor-1';
+      const response = service.remove(vendorId);
+      expect(response.message).toContain('successfully deleted');
+      expect(service.findAll()).toHaveLength(0);
+    });
+
+    it('should throw NotFoundException when trying to remove a non-existent vendor', () => {
+      expect(() => service.remove('invalid-id')).toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/vendors/vendors.controller.ts
+++ b/backend/src/vendors/vendors.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
+import { VendorsService } from './vendors.service';
+import { CreateVendorDto } from './dto/create-vendor.dto';
+import { UpdateVendorDto } from './dto/update-vendor.dto';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+
+@Controller('vendors')
+export class VendorsController {
+  constructor(private readonly vendorsService: VendorsService) {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles('admin') // Only users with the 'admin' role can access this
+  create(@Body(new ValidationPipe()) createVendorDto: CreateVendorDto) {
+    // To test this, you'd need a mock user on the request object.
+    // An auth middleware would normally handle this.
+    return this.vendorsService.create(createVendorDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.vendorsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.vendorsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body(new ValidationPipe()) updateVendorDto: UpdateVendorDto,
+  ) {
+    return this.vendorsService.update(id, updateVendorDto);
+  }
+
+  @Delete(':id')
+  @UseGuards(RolesGuard)
+  @Roles('admin') // Only users with the 'admin' role can access this
+  remove(@Param('id') id: string) {
+    return this.vendorsService.remove(id);
+  }
+}

--- a/backend/src/vendors/vendors.module.ts
+++ b/backend/src/vendors/vendors.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { VendorsService } from './vendors.service';
+import { VendorsController } from './vendors.controller';
+
+@Module({
+  controllers: [VendorsController],
+  providers: [VendorsService],
+})
+export class VendorsModule {}

--- a/backend/src/vendors/vendors.service.ts
+++ b/backend/src/vendors/vendors.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateVendorDto } from './dto/create-vendor.dto';
+import { UpdateVendorDto } from './dto/update-vendor.dto';
+import { Vendor } from './entities/vendor.entity';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class VendorsService {
+  // Using an in-memory array as a mock database
+  private readonly vendors: Vendor[] = [
+    {
+      id: 'vendor-1',
+      name: 'Agro Supplies Inc.',
+      location: 'New York',
+      inputsSold: [{ name: 'NPK 15-15-15', type: 'Fertilizer', price: 50 }],
+    },
+  ];
+
+  create(createVendorDto: CreateVendorDto): Vendor {
+    const newVendor: Vendor = {
+      id: randomUUID(),
+      ...createVendorDto,
+    };
+    this.vendors.push(newVendor);
+    return newVendor;
+  }
+
+  findAll(): Vendor[] {
+    return this.vendors;
+  }
+
+  findOne(id: string): Vendor {
+    const vendor = this.vendors.find((v) => v.id === id);
+    if (!vendor) {
+      throw new NotFoundException(`Vendor with ID "${id}" not found.`);
+    }
+    return vendor;
+  }
+
+  update(id: string, updateVendorDto: UpdateVendorDto): Vendor {
+    const vendor = this.findOne(id);
+    const vendorIndex = this.vendors.findIndex((v) => v.id === id);
+    const updatedVendor = { ...vendor, ...updateVendorDto };
+
+    this.vendors[vendorIndex] = updatedVendor;
+    return updatedVendor;
+  }
+
+  remove(id: string): { message: string } {
+    const vendorIndex = this.vendors.findIndex((v) => v.id === id);
+    if (vendorIndex === -1) {
+      throw new NotFoundException(`Vendor with ID "${id}" not found.`);
+    }
+    this.vendors.splice(vendorIndex, 1);
+    return { message: `Vendor with ID "${id}" successfully deleted.` };
+  }
+}


### PR DESCRIPTION
Closes  #4 

Description
This pull request introduces a complete CRUD (Create, Read, Update, Delete) API for managing vendors and their product offerings. This is a core feature that allows administrators to maintain a list of suppliers within the application.

The implementation includes role-based access control (RBAC) to ensure that only authorized users (admins) can create or delete vendor records, enhancing the security and integrity of the data.

Implementation Details
CRUD Endpoints:

POST /vendors: Creates a new vendor. (Admin only)

GET /vendors: Retrieves a list of all vendors.

GET /vendors/:id: Retrieves a single vendor by their ID.

PATCH /vendors/:id: Updates an existing vendor's details.

DELETE /vendors/:id: Deletes a vendor. (Admin only)

VendorsModule: A new module that encapsulates all vendor-related components (controller, service, DTOs, entity).

Vendor Entity & DTOs: Defined the data structure for a vendor and implemented CreateVendorDto and UpdateVendorDto with class-validator for robust request body validation.

Role-Based Access Control (RBAC):

Created a generic @Roles() decorator and RolesGuard to protect endpoints.

Applied the guard to the POST and DELETE endpoints to restrict access to users with the admin role.

Service Logic: The VendorsService uses an in-memory array to simulate a database, providing a fully functional mock backend for the API.

Unit Tests: Added comprehensive unit tests for both the service and controller, ensuring all business logic, data handling, and endpoint routing is correct and reliable.

How to Test
Check out this branch and run npm run start:dev.

To test as a regular user (without an admin role):

GET http://localhost:3000/vendors -> Should return a list of vendors.

GET http://localhost:3000/vendors/vendor-1 -> Should return a single vendor.

PATCH http://localhost:3000/vendors/vendor-1 with a JSON body -> Should update the vendor.

To test as an admin:

You will need to simulate an authenticated user with an admin role on the request object. In a real application, this would be handled by a JWT or session middleware.

POST http://localhost:3000/vendors with a valid vendor JSON body -> Should create a new vendor.

DELETE http://localhost:3000/vendors/vendor-1 -> Should delete the vendor.

Run all unit tests with npm run test to confirm they pass.