### PR TITLE
Implement NFT-based Product Certificate Generator

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "cloudinary": "^2.7.0",
+    "ethers": "^6.13.4",
     "nodemailer": "^7.0.5",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -31,6 +31,7 @@ import { EquipmentMarketplaceModule } from './equipment-marketplace/equipment-ma
 import { FarmZoneClassifierModule } from './farm-zone-classifier/farm-zone-classifier.module';
 import { SeedDemandPredictorModule } from './seed-demand-predictor/seed-demand-predictor.module';
 import { CropsModule } from './crops/crops.module';
+import { ProductCertificateNftModule } from './product-certificate-nft/product-certificate-nft.module';
 
 @Module({
   imports: [
@@ -73,6 +74,7 @@ import { CropsModule } from './crops/crops.module';
   AdvisoryModule,
   FeedbackModule,
   MockPurchasePlannerModule,
+  ProductCertificateNftModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/product-certificate-nft/contracts/ProductCertificateNFT.sol
+++ b/backend/src/product-certificate-nft/contracts/ProductCertificateNFT.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/token/ERC721/ERC721.sol";
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/access/Ownable.sol";
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/Strings.sol";
+
+contract ProductCertificateNFT is ERC721, Ownable {
+    using Strings for uint256;
+
+    struct Certificate {
+        string certificateHash;
+        string batchId;
+        address issuer;
+        uint256 timestamp;
+    }
+
+    uint256 private _nextTokenId = 1;
+    mapping(uint256 => Certificate) private _certificates;
+    mapping(uint256 => string) private _tokenURIs;
+
+    event CertificateMinted(uint256 indexed tokenId, address indexed to, string certificateHash, string batchId);
+
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) Ownable(msg.sender) {}
+
+    function mintCertificate(
+        address to,
+        string memory certificateHash,
+        string memory batchId,
+        string memory metadataURI
+    ) external onlyOwner returns (uint256 tokenId) {
+        tokenId = _nextTokenId++;
+        _safeMint(to, tokenId);
+        _certificates[tokenId] = Certificate({
+            certificateHash: certificateHash,
+            batchId: batchId,
+            issuer: msg.sender,
+            timestamp: block.timestamp
+        });
+        if (bytes(metadataURI).length > 0) {
+            _tokenURIs[tokenId] = metadataURI;
+        }
+        emit CertificateMinted(tokenId, to, certificateHash, batchId);
+    }
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "Nonexistent token");
+        string memory stored = _tokenURIs[tokenId];
+        if (bytes(stored).length > 0) {
+            return stored;
+        }
+        return string(abi.encodePacked("data:application/json;utf8,",
+            '{"name":"Product Certificate #', tokenId.toString(),
+            '","description":"NFT representing a product batch certificate.",',
+            '"attributes":[]}'
+        ));
+    }
+
+    function getCertificate(uint256 tokenId) external view returns (
+        string memory certificateHash,
+        string memory batchId,
+        address issuer,
+        uint256 timestamp
+    ) {
+        require(_ownerOf(tokenId) != address(0), "Nonexistent token");
+        Certificate memory c = _certificates[tokenId];
+        return (c.certificateHash, c.batchId, c.issuer, c.timestamp);
+    }
+}
+
+

--- a/backend/src/product-certificate-nft/dto/mint-certificate.dto.ts
+++ b/backend/src/product-certificate-nft/dto/mint-certificate.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEthereumAddress, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+
+export class MintCertificateDto {
+  @ApiProperty({ description: 'Recipient wallet address' })
+  @IsEthereumAddress()
+  to: string;
+
+  @ApiProperty({ description: 'Hash of certification and quality report', minLength: 32 })
+  @IsString()
+  @Length(32, 256)
+  certificateHash: string;
+
+  @ApiProperty({ description: 'Supplier product batch identifier' })
+  @IsString()
+  @IsNotEmpty()
+  batchId: string;
+
+  @ApiProperty({ description: 'Optional token metadata URI', required: false })
+  @IsString()
+  @IsOptional()
+  metadataURI?: string;
+}
+
+

--- a/backend/src/product-certificate-nft/product-certificate-nft.controller.ts
+++ b/backend/src/product-certificate-nft/product-certificate-nft.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ProductCertificateNftService } from './product-certificate-nft.service';
+import { MintCertificateDto } from './dto/mint-certificate.dto';
+
+@ApiTags('product-certificate-nft')
+@Controller('nft/certificates')
+export class ProductCertificateNftController {
+  constructor(private readonly nftService: ProductCertificateNftService) {}
+
+  @Post('mint')
+  async mintCertificate(@Body() dto: MintCertificateDto) {
+    return await this.nftService.mintCertificate(dto);
+  }
+
+  @Get(':tokenId')
+  async getTokenMetadata(@Param('tokenId') tokenId: string) {
+    return await this.nftService.getTokenMetadata(tokenId);
+  }
+}
+
+

--- a/backend/src/product-certificate-nft/product-certificate-nft.module.ts
+++ b/backend/src/product-certificate-nft/product-certificate-nft.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ProductCertificateNftService } from './product-certificate-nft.service';
+import { ProductCertificateNftController } from './product-certificate-nft.controller';
+
+@Module({
+  imports: [
+    ConfigModule.forFeature(() => ({
+      nft: {
+        rpcUrl: process.env.NFT_RPC_URL || process.env.FLARE_TESTNET_RPC || 'http://localhost:8545',
+        privateKey: process.env.NFT_PRIVATE_KEY || process.env.BLOCKCHAIN_PRIVATE_KEY,
+        contractAddress: process.env.NFT_CONTRACT_ADDRESS,
+        gasPrice: process.env.NFT_GAS_PRICE || process.env.GAS_PRICE || '25000000000',
+        gasLimit: parseInt(process.env.NFT_GAS_LIMIT || process.env.GAS_LIMIT || '500000'),
+        name: process.env.NFT_NAME || 'ProductCertificate',
+        symbol: process.env.NFT_SYMBOL || 'PCERT',
+      },
+    })),
+  ],
+  controllers: [ProductCertificateNftController],
+  providers: [ProductCertificateNftService],
+  exports: [ProductCertificateNftService],
+})
+export class ProductCertificateNftModule {}
+
+

--- a/backend/src/product-certificate-nft/product-certificate-nft.service.ts
+++ b/backend/src/product-certificate-nft/product-certificate-nft.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ethers } from 'ethers';
+import { MintCertificateDto } from './dto/mint-certificate.dto';
+
+@Injectable()
+export class ProductCertificateNftService {
+  private readonly logger = new Logger(ProductCertificateNftService.name);
+  private provider: ethers.JsonRpcProvider;
+  private wallet: ethers.Wallet | undefined;
+  private contract: ethers.Contract | undefined;
+
+  // Minimal ABI required for minting and reading
+  private readonly abi = [
+    {
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'certificateHash', type: 'string' },
+        { name: 'batchId', type: 'string' },
+        { name: 'metadataURI', type: 'string' },
+      ],
+      name: 'mintCertificate',
+      outputs: [{ name: 'tokenId', type: 'uint256' }],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    },
+    {
+      inputs: [{ name: 'tokenId', type: 'uint256' }],
+      name: 'tokenURI',
+      outputs: [{ name: '', type: 'string' }],
+      stateMutability: 'view',
+      type: 'function',
+    },
+    {
+      inputs: [{ name: 'tokenId', type: 'uint256' }],
+      name: 'getCertificate',
+      outputs: [
+        { name: 'certificateHash', type: 'string' },
+        { name: 'batchId', type: 'string' },
+        { name: 'issuer', type: 'address' },
+        { name: 'timestamp', type: 'uint256' },
+      ],
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ];
+
+  constructor(private readonly configService: ConfigService) {
+    const rpcUrl = this.configService.get<string>('nft.rpcUrl');
+    const privateKey = this.configService.get<string>('nft.privateKey');
+    const contractAddress = this.configService.get<string>('nft.contractAddress');
+
+    this.provider = new ethers.JsonRpcProvider(rpcUrl);
+    if (privateKey) {
+      this.wallet = new ethers.Wallet(privateKey, this.provider);
+    }
+    if (contractAddress && this.wallet) {
+      this.contract = new ethers.Contract(contractAddress, this.abi, this.wallet);
+    }
+  }
+
+  async mintCertificate(dto: MintCertificateDto) {
+    if (!this.contract || !this.wallet) {
+      throw new Error('NFT contract not configured');
+    }
+    const tx = await this.contract.mintCertificate(
+      dto.to,
+      dto.certificateHash,
+      dto.batchId,
+      dto.metadataURI || ''
+    );
+    const receipt = await tx.wait();
+    const event = receipt.logs?.[0];
+    return {
+      transactionHash: receipt.hash,
+      tokenId: event ? ethers.getBigInt(event.topics[event.topics.length - 1]).toString() : undefined,
+      status: receipt.status,
+    };
+  }
+
+  async getTokenMetadata(tokenId: string) {
+    if (!this.contract) {
+      throw new Error('NFT contract not configured');
+    }
+    const uri = await this.contract.tokenURI(tokenId);
+    const cert = await this.contract.getCertificate(tokenId);
+    return { tokenId, tokenURI: uri, certificate: cert };
+  }
+}
+
+

--- a/backend/src/product-certificate-nft/scripts/deploy-nft.js
+++ b/backend/src/product-certificate-nft/scripts/deploy-nft.js
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { ethers } = require('ethers');
+
+// Minimal ABI for deployment and interaction
+const CONTRACT_ABI = [
+  {
+    inputs: [
+      { internalType: 'string', name: 'name_', type: 'string' },
+      { internalType: 'string', name: 'symbol_', type: 'string' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'certificateHash', type: 'string' },
+      { name: 'batchId', type: 'string' },
+      { name: 'metadataURI', type: 'string' },
+    ],
+    name: 'mintCertificate',
+    outputs: [{ name: 'tokenId', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
+// NOTE: Replace with compiled bytecode of ProductCertificateNFT.sol
+const CONTRACT_BYTECODE = process.env.NFT_CONTRACT_BYTECODE || '0x';
+
+function getConfig() {
+  const rpcUrl = process.env.NFT_RPC_URL || process.env.FLARE_TESTNET_RPC || 'http://localhost:8545';
+  const privateKey = process.env.NFT_PRIVATE_KEY || process.env.BLOCKCHAIN_PRIVATE_KEY;
+  const name = process.env.NFT_NAME || 'ProductCertificate';
+  const symbol = process.env.NFT_SYMBOL || 'PCERT';
+  if (!privateKey) throw new Error('NFT_PRIVATE_KEY or BLOCKCHAIN_PRIVATE_KEY is required');
+  if (!CONTRACT_BYTECODE || CONTRACT_BYTECODE === '0x') throw new Error('NFT_CONTRACT_BYTECODE is required');
+  return { rpcUrl, privateKey, name, symbol };
+}
+
+async function main() {
+  const { rpcUrl, privateKey, name, symbol } = getConfig();
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, provider);
+
+  console.log(`Deployer: ${wallet.address}`);
+  const balance = await provider.getBalance(wallet.address);
+  console.log(`Balance: ${ethers.formatEther(balance)} ETH`);
+  if (balance === 0n) throw new Error('Insufficient balance');
+
+  const factory = new ethers.ContractFactory(CONTRACT_ABI, CONTRACT_BYTECODE, wallet);
+  const deployTx = await factory.deploy(name, symbol);
+  console.log('Deploying, tx:', deployTx.deploymentTransaction().hash);
+  const contract = await deployTx.waitForDeployment();
+  const address = await contract.getAddress();
+  console.log('NFT deployed at:', address);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+
+


### PR DESCRIPTION
Implement NFT-based Product Certificate Generator 

(Closes #74 )
Adds a standalone NFT module to mint ERC-721 tokens for supplier product batches, embedding a hash of their certification/quality report.
Adds ProductCertificateNFT.sol (modular ERC-721)
New Nest module product-certificate-nft with service, controller, DTO
Endpoints to mint and read certificate NFTs
Deployment script for NFT contract
Adds ethers and wires module in app.module.ts
API
POST /nft/certificates/mint — body: { to, certificateHash, batchId, metadataURI? }
GET /nft/certificates/:tokenId
Env
NFT_RPC_URL, NFT_PRIVATE_KEY, NFT_CONTRACT_ADDRESS
NFT_NAME (default ProductCertificate), NFT_SYMBOL (default PCERT)
NFT_GAS_PRICE, NFT_GAS_LIMIT
Deploy script: NFT_CONTRACT_BYTECODE (compiled bytecode)